### PR TITLE
fix(pocket): use 10m aggregated data for hourly reports

### DIFF
--- a/cmd/pocket.ts
+++ b/cmd/pocket.ts
@@ -87,7 +87,7 @@ const pocketImport = async () => {
     if (day.getTime() < aggsLimitDate.getTime()) {
       influxBucket = "mainnetRelayApp1d";
     } else {
-      influxBucket = "mainnetRelayApp60m";
+      influxBucket = "mainnetRelayApp10m";
     }
 
     if (dateDiff >= 1) {


### PR DESCRIPTION
Currently, we are using 60m aggregates to update our hourly data in the database. The script also runs every hour, so there's a big chance that our metrics data is building while the script fetches it; and get 0 as a result various times during the day.

This affected the accuracy of our demand-side protocol fees data.