### PR TITLE
Switch Sia data from SiaStats to SiaScan

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -111,7 +111,7 @@
     "symbol": "SC",
     "coingeckoID": "siacoin",
     "genesisDate": "2015-06-06",
-    "usage": "https://siastats.info/navigator-api/web3index/revenue"
+    "usage": "https://api.siascan.com/integrations/web3index/revenue"
   },
   "storj": {
     "blockchain": "Ethereum",


### PR DESCRIPTION
The data from SiaStats is no longer being updated correctly. This replaces the Sia usage endpoint from #74 with one maintained by the Sia Foundation. The calculation remains basically the same. The code can be found here: https://github.com/SiaFoundation/host-revenue-api.